### PR TITLE
Fixed 'Oh Noes!1!!' in Templates/404.html

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -9,7 +9,7 @@
       <div class="jumbotron">
         <div class="row">
           <div class="col-xs-12 col-sm-7">
-            <h1>Oh Noes!1!!</h1>
+            <h1>Oh Noes!!!!</h1>
             <h2>Error 404</h2>
             <p>Sorry, we couldn't find the thing you were looking for. Try searching for it.</p>
             <form action="http://www.thebluealliance.com/search">


### PR DESCRIPTION
Fixing the 1 next to Oh Noes!1!! on the 404.html page, assuming it was a mistake.

![capture](https://cloud.githubusercontent.com/assets/12914467/8217652/53e2722a-1504-11e5-8192-909a0161b4b5.PNG)

